### PR TITLE
Update Node and Firefox

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.0.6
+
+- Update node to 8.9.1
+- Update Firefox to v57.0
+
 ## v0.0.5
 
 - Base on Circle's Ruby image

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,30 +23,28 @@ RUN sudo apt-get install -y \
 USER root
 
 ############ BEGIN NODE DOCKERFILE ####################
-# COPY-PASTED FROM NODE 6 INSTALLATION FROM https://raw.githubusercontent.com/nodejs/docker-node/master/6.11/Dockerfile
-
+# COPY-PASTED FROM NODE 8 INSTALLATION FROM https://raw.githubusercontent.com/nodejs/docker-node/master/8/Dockerfile
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \
   && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
     94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
     FD3A5288F042B6850C66B31F09FE44734EB7990E \
     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
     DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
     gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
   done
 
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.11.3
+ENV NODE_VERSION 8.9.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -55,25 +53,26 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
   && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 0.27.5
+ENV YARN_VERSION 1.3.2
 
 RUN set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"  || \
     gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key"; \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
   done \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,17 +89,17 @@ RUN set -ex \
 
 # Install geckodriver
 RUN \
-    url=https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz \
+    url=https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz \
     && curl -s -L "$url" | tar -xz \
     && chmod +x geckodriver \
     && mv geckodriver /usr/local/bin
 
 
 ########
-# install firefox v52
+# install firefox
 ENV PATH /firefox:$PATH
-RUN FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/55.0.3/linux-x86_64/en-US/firefox-55.0.3.tar.bz2" \
-    FIREFOX_SHA256="f0fd11357de7250660f1a5c5b209c44de1d0f50bb1d3444dd2afad6b41e15b9d" \
+RUN FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/57.0/linux-x86_64/en-US/firefox-57.0.tar.bz2" \
+    FIREFOX_SHA256="c2cae016089e816c03283a359c582efab3bca34e6048ecc2382b43c1eb342457" \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar.bz2 $FIREFOX_URL \
   && echo "$FIREFOX_SHA256 /tmp/firefox.tar.bz2" | sha256sum -c \
   && tar -jxf /tmp/firefox.tar.bz2 \

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Our base CircleCI image.
 - Circle CI's Ruby docker image.
 - qt5 (for Capybara Webkit) and postgresql-client installed from apt.
-- Node 6 (from Joyent's dockerfiles)
 - Firefox ESR
+- Node 8.9.1 (from Joyent's dockerfiles)
 - Geckodriver
 - Chrome latest
 - Chromedriver

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 Our base CircleCI image.
 - Circle CI's Ruby docker image.
 - qt5 (for Capybara Webkit) and postgresql-client installed from apt.
-- Firefox ESR
 - Node 8.9.1 (from Joyent's dockerfiles)
+- Firefox v57 (aka Quantum)
 - Geckodriver
 - Chrome latest
-- Chromedriver
+- Chromedriver latest
 
 ## Build
 


### PR DESCRIPTION
- Update Node to 8.9.1 which is what we are starting to use in dev/prod.
- Update Firefox to latest version (57.0) aka "Quantum", since it is a big release.