### PR TITLE
[Ruby] Update base image to be circleci/ruby:2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.5.0
+FROM circleci/ruby:2.5.1
 
 RUN sudo apt-get update
 RUN sudo apt-get install -y \


### PR DESCRIPTION
- This version of Ruby was released a few days ago, and contains some bug fixes and security updates.
- `docker build .` works on my machine