### PR TITLE
Add codeclimate test reporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,21 @@ FROM circleci/ruby:2.5.1
 
 RUN sudo apt-get update
 RUN sudo apt-get install -y \
-    libqt5webkit5-dev\
-    qt5-default\
-    postgresql-client\
-    lsof \
-    libasound2 \
-    libgtk-3-0 \
-    libstartup-notification0 \
-    gconf-service \
-    libgconf-2-4 \
-    libnspr4 \
-    libxss1 \
-    fonts-liberation \
-    libappindicator1 \
-    libnss3 \
-    xdg-utils
+  libqt5webkit5-dev\
+  qt5-default\
+  postgresql-client\
+  lsof \
+  libasound2 \
+  libgtk-3-0 \
+  libstartup-notification0 \
+  gconf-service \
+  libgconf-2-4 \
+  libnspr4 \
+  libxss1 \
+  fonts-liberation \
+  libappindicator1 \
+  libnss3 \
+  xdg-utils
 
 USER root
 
@@ -87,23 +87,27 @@ RUN set -ex \
 
 # install chrome
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-      && (dpkg -i /tmp/google-chrome-stable_current_amd64.deb || apt-get -fy install)  \
-      && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
-      && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
-           "/opt/google/chrome/google-chrome" \
-      && google-chrome --version
+  && (dpkg -i /tmp/google-chrome-stable_current_amd64.deb || apt-get -fy install)  \
+  && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
+  && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
+    "/opt/google/chrome/google-chrome" \
+  && google-chrome --version
 
 # Install ChromeDriver
 RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
-      && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
-      && cd /tmp \
-      && unzip chromedriver_linux64.zip \
-      && rm -rf chromedriver_linux64.zip \
-      && mv chromedriver /usr/local/bin/chromedriver \
-      && chmod +x /usr/local/bin/chromedriver \
-      && chromedriver --version
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
+  && cd /tmp \
+  && unzip chromedriver_linux64.zip \
+  && rm -rf chromedriver_linux64.zip \
+  && mv chromedriver /usr/local/bin/chromedriver \
+  && chmod +x /usr/local/bin/chromedriver \
+  && chromedriver --version
 
 ################## END BROWSERS #####################
+
+# install CodeClimate test reporter for coverage reporting
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter \
+  && chmod +x /usr/local/bin/cc-test-reporter
 
 # Set DISPLAY for xvfb (for Firefox).
 # Note: need to start this manually in Circle.

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,25 +85,6 @@ RUN set -ex \
 
 ################ BEGIN BROWSERS #####################
 
-# Install geckodriver
-RUN \
-    url=https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz \
-    && curl -s -L "$url" | tar -xz \
-    && chmod +x geckodriver \
-    && mv geckodriver /usr/local/bin
-
-
-########
-# install firefox
-ENV PATH /firefox:$PATH
-RUN FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/57.0/linux-x86_64/en-US/firefox-57.0.tar.bz2" \
-    FIREFOX_SHA256="c2cae016089e816c03283a359c582efab3bca34e6048ecc2382b43c1eb342457" \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar.bz2 $FIREFOX_URL \
-  && echo "$FIREFOX_SHA256 /tmp/firefox.tar.bz2" | sha256sum -c \
-  && tar -jxf /tmp/firefox.tar.bz2 \
-  && rm /tmp/firefox.tar.bz2 \
-  && firefox --version
-
 # install chrome
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
       && (dpkg -i /tmp/google-chrome-stable_current_amd64.deb || apt-get -fy install)  \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Our base CircleCI image.
 - Node 8.9.1 (from Joyent's dockerfiles)
 - Chrome latest
 - Chromedriver latest
+- CodeClimate reporter
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 ## Intro
 
 Our base CircleCI image.
+
 - Circle CI's Ruby docker image.
 - qt5 (for Capybara Webkit) and postgresql-client installed from apt.
 - Node 8.9.1 (from Joyent's dockerfiles)
-- Firefox v57 (aka Quantum)
-- Geckodriver
 - Chrome latest
 - Chromedriver latest
 


### PR DESCRIPTION
This adds the codeclimate test reporter to the base dockerfile so it will be available to all containers globally and doesn't need to be reinstalled on every single build. The reporter allows us to send coverage data directly to them.